### PR TITLE
Update fastqc module resource allocation in main.nf

### DIFF
--- a/modules/nf-core/fastqc/main.nf
+++ b/modules/nf-core/fastqc/main.nf
@@ -1,6 +1,6 @@
 process FASTQC {
     tag "$meta.id"
-    label 'process_low'
+    label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
Updated resource allocation for fastqc from 'process_low' to 'process_medium' which has the following definition: cpus = { check_max( 6 * task.attempt, 'cpus' ) } 
memory = { check_max( 36.GB * task.attempt, 'memory' ) }  time = { check_max( 8.h * task.attempt, 'time' ) } as defined in the base.config file